### PR TITLE
upgrade to quarkus v2. add ability to get version of a single component

### DIFF
--- a/deployment/templates/deploymentconfig.yaml
+++ b/deployment/templates/deploymentconfig.yaml
@@ -35,7 +35,7 @@ spec:
             name: status-configuration
         readinessProbe:
           httpGet:
-            path: /health/ready
+            path: /q/health/ready
             port: 8080
             scheme: HTTP
           timeoutSeconds: 1
@@ -44,7 +44,7 @@ spec:
           failureThreshold: 3
         livenessProbe:
           httpGet:
-            path: /health/live
+            path: /q/health/live
             port: 8080
             scheme: HTTP
           timeoutSeconds: 1

--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,9 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>1.6.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.6.1.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.4.2.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <lombok.version>1.18.12</lombok.version>
         <sonar.projectKey>rht-labs_lodestar-status</sonar.projectKey>
@@ -98,7 +97,7 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
-                <version>${quarkus-plugin.version}</version>
+                <version>${quarkus.platform.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/com/redhat/labs/lodestar/model/version/VersionManifest.java
+++ b/src/main/java/com/redhat/labs/lodestar/model/version/VersionManifest.java
@@ -28,9 +28,13 @@ public class VersionManifest {
 
     @JsonbProperty("main_version")
     public Version getMainVersion() {
+        return getVersion(mainVersionKey);
+    }
+
+    public Version getVersion(String component) {
         Optional<Version> optional = applications.stream()
-                .filter(a -> a.getApplication().equalsIgnoreCase(mainVersionKey)).findFirst();
-        return optional.isPresent() ? optional.get() : null;
+                .filter(a -> a.getApplication().equalsIgnoreCase(component)).findFirst();
+        return optional.orElse(new Version());
     }
 
     @JsonbProperty("component_versions")

--- a/src/main/java/com/redhat/labs/lodestar/resource/VersionResource.java
+++ b/src/main/java/com/redhat/labs/lodestar/resource/VersionResource.java
@@ -3,11 +3,9 @@ package com.redhat.labs.lodestar.resource;
 import javax.annotation.security.PermitAll;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Timed;
@@ -31,6 +29,17 @@ public class VersionResource {
     @Counted(name = "versionManifestResourceCounter")
     public VersionManifest getVersionManifest() {
         return versionManifestConfig.getVersionData();
+    }
+
+    @GET
+    @PermitAll
+    @Path("/manifest/{component}")
+    @Timed(name = "versionManifestComponentResourceTimer")
+    @Counted(name = "versionManifestComponentResourceCounter")
+    public Response getVersionManifestComponent(@PathParam("component") String component) {
+        VersionManifest vm = versionManifestConfig.getVersionData();
+
+        return Response.ok(vm.getVersion(component)).build();
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@ quarkus.log.category."com.redhat.labs.lodestar".level=${LODESTAR_STATUS_LOGGING:
 quarkus.http.cors=true
 
 # create the uber jar
-quarkus.package.uber-jar=true
+quarkus.package.type=uber-jar
 
 # open api
 quarkus.swagger-ui.always-include=true

--- a/src/test/java/com/redhat/labs/lodestar/health/StatusLivenessCheckTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/health/StatusLivenessCheckTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
-public class StatusLIvenessCheckTest {
+public class StatusLivenessCheckTest {
 
     @Inject
     @Liveness
@@ -26,8 +26,8 @@ public class StatusLIvenessCheckTest {
 
         assertNotNull(response);
         assertEquals("STATUS LIVENESS", response.getName());
-        assertNotNull(response.getState());
-        assertEquals("UP", response.getState().name());
+        assertNotNull(response.getStatus());
+        assertEquals("UP", response.getStatus().name());
 
     }
 

--- a/src/test/java/com/redhat/labs/lodestar/health/StatusReadinessCheckTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/health/StatusReadinessCheckTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Arrays;
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -41,8 +42,8 @@ public class StatusReadinessCheckTest {
         // then
         assertNotNull(response);
         assertEquals("STATUS READINESS", response.getName());
-        assertNotNull(response.getState());
-        assertEquals("DOWN", response.getState().name());
+        assertNotNull(response.getStatus());
+        assertEquals("DOWN", response.getStatus().name());
 
     }
 
@@ -58,8 +59,8 @@ public class StatusReadinessCheckTest {
         // then
         assertNotNull(response);
         assertEquals("STATUS READINESS", response.getName());
-        assertNotNull(response.getState());
-        assertEquals("DOWN", response.getState().name());
+        assertNotNull(response.getStatus());
+        assertEquals("DOWN", response.getStatus().name());
 
     }
 
@@ -68,7 +69,7 @@ public class StatusReadinessCheckTest {
 
         // given
         VersionManifest vm = VersionManifest.builder().mainVersionKey("lodestar")
-                .applications(Arrays.asList(Version.builder().application("lodestar").build()))
+                .applications(List.of(Version.builder().application("lodestar").build()))
                 .build();
         Mockito.when(config.getVersionData()).thenReturn(vm);
 
@@ -78,8 +79,8 @@ public class StatusReadinessCheckTest {
         // then
         assertNotNull(response);
         assertEquals("STATUS READINESS", response.getName());
-        assertNotNull(response.getState());
-        assertEquals("DOWN", response.getState().name());
+        assertNotNull(response.getStatus());
+        assertEquals("DOWN", response.getStatus().name());
 
     }
 
@@ -98,8 +99,8 @@ public class StatusReadinessCheckTest {
         // then
         assertNotNull(response);
         assertEquals("STATUS READINESS", response.getName());
-        assertNotNull(response.getState());
-        assertEquals("UP", response.getState().name());
+        assertNotNull(response.getStatus());
+        assertEquals("UP", response.getStatus().name());
 
     }
 

--- a/src/test/java/com/redhat/labs/lodestar/resource/VersionResourceTest.java
+++ b/src/test/java/com/redhat/labs/lodestar/resource/VersionResourceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import com.redhat.labs.lodestar.utils.ResourceLoader;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 
 @QuarkusTest
@@ -21,6 +22,32 @@ public class VersionResourceTest {
           .then()
              .statusCode(200)
              .body(is(expected));
+    }
+
+    @Test
+    public void testGetVersionComponentManifest() {
+
+        String expected = ResourceLoader.load("data/version/get-version-manifest.json");
+
+        given()
+                .when().get("/api/v1/version/manifest/launcher")
+                .then()
+                .statusCode(200)
+                .body("name", equalTo("launcher"))
+                .body("value", equalTo("v1.1"));
+    }
+
+    @Test
+    public void testGetVersionComponentManifestEmpty() {
+
+        String expected = ResourceLoader.load("data/version/get-version-manifest.json");
+
+        given()
+                .when().get("/api/v1/version/manifest/nada")
+                .then()
+                .statusCode(200)
+                .body("name", equalTo(null))
+                .body("value", equalTo(null));
     }
 
 }


### PR DESCRIPTION
- upgrades to v2 quaarkus
- adds api to get the version of a specific component so that an another app (activity) can call the correct api without sync'ing versions.